### PR TITLE
Remove trailing comma in defaults object

### DIFF
--- a/jquery.countTo.js
+++ b/jquery.countTo.js
@@ -41,6 +41,6 @@
 		refreshInterval: 100,  // how often the element should be updated
 		decimals: 0,  // the number of decimal places to show
 		onUpdate: null,  // callback method for every time the element is updated,
-		onComplete: null,  // callback method for when the element finishes updating
+		onComplete: null  // callback method for when the element finishes updating
 	};
 }(jQuery));


### PR DESCRIPTION
Stop IEs from choking (hello again IE6/7, but more importantly "Compatibility View" and "Quirks"-mode in IE8/9).

Just ran into this in IE9 – forgot the proper `doctype` which put IE9 in "Quirks" document mode.
