### PR TITLE
Use jquery text instead of html.

### DIFF
--- a/jquery.countTo.js
+++ b/jquery.countTo.js
@@ -58,7 +58,7 @@
 
 			function render(value) {
 				var formattedValue = settings.formatter.call(self, value, settings);
-				$self.html(formattedValue);
+				$self.text(formattedValue);
 			}
 		});
 	};


### PR DESCRIPTION
The jquery <code>html</code> function does not work for svg text elements which was my use case. Since we should never be displaying html anyways I thought this could make the library slightly more multifunctional. Great plugin btw, really enjoy it.
