### PR TITLE
Ensure that negative 0 will be displayed as 0

### DIFF
--- a/jquery.countTo.js
+++ b/jquery.countTo.js
@@ -75,6 +75,6 @@
 	};
 
 	function formatter(value, settings) {
-		return value.toFixed(settings.decimals);
+		return +value.toFixed(settings.decimals);
 	}
 }(jQuery));


### PR DESCRIPTION
Javascript's `toFixed` function will allow for -0 zero to be displayed. I didn't think this is ideal for the default formatter so I changed it. Here's an example of what I'm talking about: http://jsfiddle.net/LUwD6/

The plus sign with implicitly convert it to an integer and when -0 gets turned to an integer, the `toString` method (which will be called when displayed) the value will automatically display as 0 instead of -0.